### PR TITLE
Security Fix for Arbitrary Code Execution - huntr.dev

### DIFF
--- a/mosc.js
+++ b/mosc.js
@@ -49,8 +49,14 @@ var MoscBase = function (evaluation_context_dictionary)
 		    	{
 				// arbitary code execution mitigation
 				let blacklist = ['&', ';', '|', '-', '$', '`', '||'];
-				if (blacklist.some(v => get_eval_string(pvalue).includes(v))) {
-					break;
+				let escapedString = get_eval_string(pvalue);
+				if (blacklist.some(v => escapedString.includes(v))) {
+					for(var i=0; i<escapedString.length; i++){
+						if(blacklist.includes(escapedString[i])){
+							escapedString = escapedString.replace(escapedString[i], "");
+						}
+					}
+					propertyBase[property_parts[0]] = eval(escapedString);
 				} else {
 		    			propertyBase[property_parts[0]] = eval(get_eval_string(pvalue));
 				}

--- a/mosc.js
+++ b/mosc.js
@@ -47,7 +47,13 @@ var MoscBase = function (evaluation_context_dictionary)
 		    {
 		    	try
 		    	{
-		    		propertyBase[property_parts[0]] = eval(get_eval_string(pvalue));
+				// arbitary code execution mitigation
+				let blacklist = ['&', ';', '|', '-', '$', '`', '||'];
+				if (blacklist.some(v => get_eval_string(pvalue).includes(v))) {
+					break;
+				} else {
+		    			propertyBase[property_parts[0]] = eval(get_eval_string(pvalue));
+				}
 		    	}
 		    	catch(e)
 		    	{


### PR DESCRIPTION
https://huntr.dev/users/Asjidkalam has fixed the Arbitrary Code Execution vulnerability 🔨. Asjidkalam has been awarded $25 for fixing the vulnerability through the huntr bug bounty program 💵. Think you could fix a vulnerability like this?

Get involved at https://huntr.dev/

Q | A
Version Affected | ALL
Bug Fix | YES
Original Pull Request | https://github.com/418sec/mosc/pull/1
GitHub Issue URL | https://github.com/4y0/mosc/issues/1
Vulnerability README | https://github.com/418sec/huntr/blob/master/bounties/npm/mosc/1/README.md

### User Comments:

### 📊 Metadata *

Arbitrary code execution vulnerability using `eval()`
#### Bounty URL:  https://www.huntr.dev/app/bounties/open/1-npm-mosc

### ⚙️ Description *

Fixed the arbitrary code execution by checking for command injection characters in the input passed to `eval()`

### 💻 Technical Description *

There is an instance in `mosc.js` file where the user-supplied input is passed directly to the `eval()` without any sanitization. This can be very dangerous as malicious users could inject commands to execute arbitrary code. Since the input is directly passed to `eval()`, we can check for possible command injection characters in the input by using a blacklist array.

### 🐛 Proof of Concept (PoC) *

Create a project with a vulnerable package and run the following snippet, the code executed will create a file named `HACKED` in the working directory.

```javascript
var A = require("mosc");
var a = new A({});
var key = "";
var attack_code = "fs=require('fs');fs.writeFile('HACKED');"
var properties = "{a:*1*; " + attack_code + " //*}"

var a = a.parse_properties(key,properties,{},{})
```

![before](https://user-images.githubusercontent.com/16708391/88830196-3d0cf300-d1eb-11ea-9c78-85fb2d605734.PNG)

### 🔥 Proof of Fix (PoF) *

After applying the fix, it checks if any symbols(*other than symbols used to build object models*) are used, if found it terminates without executing the `eval()`. Hence code execution is mitigated.

![after](https://user-images.githubusercontent.com/16708391/88832482-814dc280-d1ee-11ea-828e-9ba1a38d6d25.PNG)

### 👍 User Acceptance Testing (UAT)

No new libraries are introduced, and no values are changed. It prevents the `eval()` to be executed if a command injection symbol is present in the input.

![uat](https://user-images.githubusercontent.com/16708391/88832723-d689d400-d1ee-11ea-9749-3e3edb3567e6.PNG)
